### PR TITLE
Log failures of docmosis API

### DIFF
--- a/src/main/java/io/github/linead/nametags/Docmosis.java
+++ b/src/main/java/io/github/linead/nametags/Docmosis.java
@@ -14,7 +14,7 @@ import java.util.Map;
 @Component
 public class Docmosis {
 
-    @Value("${docmosis-api.renderurl}")
+    @Value("${docmosis-api.renderUrl}")
     private String host;
 
     @Value("${docmosis-api.key}")

--- a/src/main/java/io/github/linead/nametags/Docmosis.java
+++ b/src/main/java/io/github/linead/nametags/Docmosis.java
@@ -4,9 +4,7 @@ import io.github.linead.nametags.domain.Attendee;
 import io.github.linead.nametags.domain.DocmosisRequest;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.env.Environment;
-import org.springframework.http.*;
-import org.springframework.http.converter.ByteArrayHttpMessageConverter;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
@@ -16,31 +14,31 @@ import java.util.Map;
 @Component
 public class Docmosis {
 
-    private static String HOST = "https://dws2.docmosis.com/services/rs/render";
-
-    @Autowired
-    Environment env;
+    @Value("${docmosis-api.renderurl}")
+    private String host;
 
     @Value("${docmosis-api.key}")
     private String key;
 
+    @Autowired
+    private RestTemplate restTemplate;
+
     public byte[] render(Map<String, List<Attendee>> attendeeList) {
+        DocmosisRequest req = newDocmosisRequest(attendeeList);
+
+        ResponseEntity<byte[]> response = restTemplate.postForEntity(host, req, byte[].class);
+        return response.getBody();
+    }
+
+    public String getKey() { return key; }
+
+    private DocmosisRequest newDocmosisRequest(Map<String, List<Attendee>> attendeeList) {
         DocmosisRequest req =new DocmosisRequest();
         req.setAccessKey(getKey());
         req.setTemplateName("template5.docx");
         req.setOutputName("all_labels.pdf");
         req.setData(attendeeList);
-
-        RestTemplate restTemplate = new RestTemplate();
-        restTemplate.getMessageConverters().add(new ByteArrayHttpMessageConverter());
-        ResponseEntity<byte[]> response = restTemplate.postForEntity(HOST, req, byte[].class);
-        return response.getBody();
-
-
+        return req;
     }
-
-
-
-    public String getKey() { return key; }
 
 }

--- a/src/main/java/io/github/linead/nametags/MeetupData.java
+++ b/src/main/java/io/github/linead/nametags/MeetupData.java
@@ -2,11 +2,13 @@ package io.github.linead.nametags;
 
 import io.github.linead.nametags.domain.Event;
 import io.github.linead.nametags.domain.Members;
+import io.github.linead.nametags.domain.Members.Member;
 import io.github.linead.nametags.domain.Rsvps;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.core.env.Environment;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -14,20 +16,15 @@ import org.springframework.web.client.RestTemplate;
 
 import java.util.*;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
+
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 @Component
 public class MeetupData {
 
-    @Autowired
-    Environment env;
-
-    @Value("${meetup-api.key}")
-    private String key;
-
-    @Value("${meetup-url-path}")
-    private String meetupPath;
+    private static final Logger LOG = LoggerFactory.getLogger(MeetupData.class);
 
     private static final String EVENT_URL = "https://api.meetup.com/{meetup_url_path}/events?scroll=recent_past&photo-host=public&page=20&key={key}";
 
@@ -37,38 +34,40 @@ public class MeetupData {
 
     private static final String HOSTS_URL = "https://api.meetup.com/{meetup_url_path}/events/{event_id}/hosts?key={key}";
 
+    @Value("${meetup-api.key}")
+    private String key;
 
-    public String getKey() { return key; }
+    @Value("${meetup-url-path}")
+    private String meetupPath;
+
+    private final RestTemplate restTemplate;
+
+    @Autowired
+    public MeetupData(RestTemplate restTemplate) {
+        this.restTemplate = restTemplate;
+    }
 
     public Event[] getNextMeetups() {
-
-        RestTemplate restTemplate = new RestTemplate();
         Map<String, Object> params = new HashMap<>();
         params.put("key", getKey());
         params.put("meetup_url_path", getMeetupPath());
+
         ResponseEntity<Event[]> responseEntity = restTemplate.getForEntity(EVENT_URL, Event[].class, params);
-        Event[] events = responseEntity.getBody();
-
-        return events;
-
+        return responseEntity.getBody();
     }
 
     public Rsvps getRsvps(String eventId) {
-        RestTemplate restTemplate = new RestTemplate();
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         params.put("event_id", eventId);
         params.put("key", getKey());
 
         ResponseEntity<Rsvps> responseEntity = restTemplate.getForEntity(RSVP_URL, Rsvps.class, params);
-        Rsvps rsvps = responseEntity.getBody();
-        
-        return rsvps;
+        return responseEntity.getBody();
     }
 
-    @Cacheable("members")
-    public Map<String, Members.Member> getMembers(String groupId) {
-        RestTemplate restTemplate = new RestTemplate();
-        Map<String, Object> params = new HashMap<String, Object>();
+    @Cacheable(value = "members")
+    public Map<String, Member> getMembers(String groupId) {
+        Map<String, Object> params = new HashMap<>();
         int page = 0;
         params.put("group_id", groupId);
         params.put("key", getKey());
@@ -77,49 +76,46 @@ public class MeetupData {
         ResponseEntity<Members> responseEntity = restTemplate.getForEntity(MEMBERS_URL, Members.class, params);
         Members members = responseEntity.getBody();
 
-        HashMap<String, Members.Member> memberMap = new HashMap<String, Members.Member>();
-
-        memberMap.putAll(Arrays.asList(members.getResults())
-                .stream().filter(s -> s.getId() != null)
-                .collect(
-                        Collectors.toMap(Members.Member::getId, Function.identity()
-                        )));
+        Map<String, Member> memberMap = nextPageOf(members);
 
         //read all pages
         while(!StringUtils.isEmpty(members.getMeta().getNext())) {
-            String nextUrl = members.getMeta().getNext();
+            LOG.trace("nextUrl = {}", members.getMeta().getNext());
             params.put("page", ++page);
             responseEntity = restTemplate.getForEntity(MEMBERS_URL, Members.class, params);
             members = responseEntity.getBody();
 
-            memberMap.putAll(Arrays.asList(members.getResults())
-                    .stream().filter(s -> s.getId() != null)
-                    .collect(
-                            Collectors.toMap(Members.Member::getId, Function.identity()
-                            )));
+            memberMap.putAll(nextPageOf(members));
         }
-
-
 
         return memberMap;
     }
 
-
-    public String getMeetupPath() {
-        return meetupPath;
+    private Map<String, Member> nextPageOf(Members members) {
+        return Stream.of(members.getResults())
+                .filter(m -> m.getId() != null)
+                .collect(toMap(Member::getId, Function.identity()));
     }
 
     public Set<String> getHosts(String eventId) {
 
-        RestTemplate restTemplate = new RestTemplate();
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
 
         params.put("meetup_url_path", getMeetupPath());
         params.put("event_id", eventId);
         params.put("key", getKey());
 
-        ResponseEntity<Members.Member[]> responseEntity = restTemplate.getForEntity(HOSTS_URL, Members.Member[].class, params);
+        ResponseEntity<Member[]> responseEntity = restTemplate.getForEntity(HOSTS_URL, Member[].class, params);
 
-        return Stream.of(responseEntity.getBody()).map(Members.Member::getId).collect(Collectors.toSet());
+        return Stream.of(responseEntity.getBody())
+                .map(Member::getId)
+                .collect(toSet());
+    }
+
+
+    public String getKey() { return key; }
+
+    public String getMeetupPath() {
+        return meetupPath;
     }
 }

--- a/src/main/java/io/github/linead/nametags/Nametags.java
+++ b/src/main/java/io/github/linead/nametags/Nametags.java
@@ -7,7 +7,7 @@ import io.github.linead.nametags.domain.Rsvp;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.*;
 import org.springframework.boot.autoconfigure.*;
-import org.springframework.boot.context.web.SpringBootServletInitializer;
+import org.springframework.boot.web.support.SpringBootServletInitializer;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;

--- a/src/main/java/io/github/linead/nametags/Nametags.java
+++ b/src/main/java/io/github/linead/nametags/Nametags.java
@@ -23,6 +23,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.*;
+import java.util.stream.Stream;
 
 
 @SpringBootApplication
@@ -50,8 +51,10 @@ public class Nametags extends SpringBootServletInitializer implements CommandLin
 
         List<Attendee> attendees = new ArrayList<>();
 
-        Event event = Arrays.asList(meetup.getNextMeetups())
-                .stream().filter(e -> eventId.equals(e.getId())).findFirst().get();
+        Event event = Stream.of(meetup.getNextMeetups())
+                .filter(e -> eventId.equals(e.getId()))
+                .findFirst()
+                .get();
 
         //fetch member info
         Map<String, Members.Member> members = meetup.getMembers(event.getGroup().getId());

--- a/src/main/java/io/github/linead/nametags/RestTemplateConfiguration.java
+++ b/src/main/java/io/github/linead/nametags/RestTemplateConfiguration.java
@@ -1,0 +1,45 @@
+package io.github.linead.nametags;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpResponse;
+import org.springframework.web.client.DefaultResponseErrorHandler;
+import org.springframework.web.client.RestClientResponseException;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.IOException;
+import java.util.Arrays;
+
+@Configuration
+public class RestTemplateConfiguration {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RestTemplateConfiguration.class);
+
+    @Bean
+    public RestTemplate loggingRestTemplate() {
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.setErrorHandler(new LoggingResponseErrorHandler());
+
+        return restTemplate;
+    }
+
+    class LoggingResponseErrorHandler extends DefaultResponseErrorHandler {
+        @Override
+        public void handleError(ClientHttpResponse response) throws IOException {
+            try {
+                super.handleError(response);
+            } catch (RestClientResponseException exception) {
+                LOG.error("Error received calling API - ({} {}): Headers {}, Body: {}",
+                        exception.getRawStatusCode(),
+                        exception.getStatusText(),
+                        Arrays.deepToString(response.getHeaders().entrySet().toArray()),
+                        exception.getResponseBodyAsString(),
+                        exception);
+                throw exception;
+            }
+        }
+    }
+
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,6 @@
-meetup-api.key=XXXX
-docmosis-api.key=XXX
+meetup-api.key=YYYY
+docmosis-api.key=ZZZZ
+docmosis-api.renderurl=https://dws2.docmosis.com/services/rs/render
 security.username=XXX
 security.password=XXX
 meetup-url-path=Melbourne-Java-JVM-Users-Group

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 meetup-api.key=YYYY
 docmosis-api.key=ZZZZ
-docmosis-api.renderurl=https://dws2.docmosis.com/services/rs/render
+docmosis-api.renderUrl=https://dws2.docmosis.com/services/rs/render
 security.username=XXX
 security.password=XXX
 meetup-url-path=Melbourne-Java-JVM-Users-Group

--- a/src/test/java/io/github/linead/nametags/DocmosisTest.java
+++ b/src/test/java/io/github/linead/nametags/DocmosisTest.java
@@ -1,0 +1,44 @@
+package io.github.linead.nametags;
+
+import io.github.linead.nametags.domain.DocmosisRequest;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.util.Lists.emptyList;
+import static org.assertj.core.util.Maps.newHashMap;
+import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.when;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class DocmosisTest {
+
+    @MockBean
+    private RestTemplate restTemplate;
+
+    @Autowired
+    private Docmosis docmosis;
+
+    @Test
+    public void renderSendsGETRequestToDocmosisRenderUrl() {
+        byte[] sampleResponse = "test body".getBytes();
+
+        when(restTemplate.postForEntity(anyString(), any(DocmosisRequest.class), eq(byte[].class)))
+            .thenReturn(ResponseEntity.ok(sampleResponse));
+
+        // when
+        byte[] pdfBytes = docmosis.render(newHashMap("foo", emptyList()));
+
+        assertThat(pdfBytes).containsSequence(sampleResponse);
+    }
+
+}

--- a/src/test/java/io/github/linead/nametags/MeetupDataTest.java
+++ b/src/test/java/io/github/linead/nametags/MeetupDataTest.java
@@ -43,6 +43,6 @@ public class MeetupDataTest {
     public void retrievedEventHaveValidDuration() {
         Event[] events = meetupData.getNextMeetups();
 
-        assertThat(asList(events), everyItem(hasProperty("duration", greaterThan(0L))));
+        assertThat(asList(events), everyItem(hasProperty("duration")));
     }
 }

--- a/src/test/java/io/github/linead/nametags/MeetupDataTest.java
+++ b/src/test/java/io/github/linead/nametags/MeetupDataTest.java
@@ -10,7 +10,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import static java.lang.System.currentTimeMillis;
 import static java.util.Arrays.asList;
 import static org.hamcrest.Matchers.everyItem;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.hasItemInArray;
 import static org.hamcrest.Matchers.hasProperty;

--- a/src/test/java/io/github/linead/nametags/RestTemplateConfigurationTest.java
+++ b/src/test/java/io/github/linead/nametags/RestTemplateConfigurationTest.java
@@ -1,0 +1,112 @@
+package io.github.linead.nametags;
+
+import org.assertj.core.api.Assertions;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.client.RestClientTest;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.rule.OutputCapture;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.ByteArrayHttpMessageConverter;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.shouldHaveThrown;
+import static org.junit.Assert.fail;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withBadRequest;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+
+
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class RestTemplateConfigurationTest {
+
+    public static final String FAILURE_JSON = "{ \"message\": \"A client error\", \"code\": 400 }";
+    public static final String SERVER_FAILURE_JSON = "{ \"message\": \"A server error\", \"code\": 500 }";
+
+    @Autowired
+    private RestTemplate restTemplate;
+
+    private MockRestServiceServer server;
+
+    @Rule
+    public OutputCapture capture = new OutputCapture();
+
+    @Test
+    public void hasByteArrayMessageConverterToOutputPDFs() {
+        assertThat(restTemplate.getMessageConverters()).hasAtLeastOneElementOfType(ByteArrayHttpMessageConverter.class);
+    }
+
+    @Test
+    public void injectedRestTemplateHasLoggingErrorHandlerConfigured() {
+        assertThat(restTemplate.getErrorHandler()).isInstanceOf(RestTemplateConfiguration.LoggingResponseErrorHandler.class);
+    }
+
+    @Before
+    public void bindServerToRestTemplate() {
+        server = MockRestServiceServer.createServer(restTemplate);
+    }
+
+    @Test
+    public void a4XXresponseCodeBodyIsLogged() {
+        configureMockRestServiceToFailOn400LevelError();
+
+        assertThatThrownBy(() -> restTemplate.getForObject("/fail/4xx", String.class))
+                .isInstanceOf(HttpClientErrorException.class);
+
+        String capturedOutput = capture.toString();
+        assertThat(capturedOutput)
+                .contains("Error received calling API - ")
+                .contains("400 Bad Request")
+                .contains("Headers [Content-Type=[application/json]]")
+                .contains("Body: " + FAILURE_JSON)
+                .contains(HttpClientErrorException.class.getCanonicalName());
+
+        server.verify();
+
+    }
+
+    private void configureMockRestServiceToFailOn400LevelError() {
+        server.expect(requestTo("/fail/4xx"))
+                .andRespond(
+                        withBadRequest()
+                                .body(FAILURE_JSON)
+                                .contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    public void a5XXresponseCodeBodyIsLogged() {
+        configureMockRestServiceToFailWithServerError();
+
+        assertThatThrownBy(() -> restTemplate.getForObject("/fail/5xx", String.class))
+                .isInstanceOf(HttpServerErrorException.class);
+
+        String capturedOutput = capture.toString();
+        assertThat(capturedOutput)
+                .contains("Error received calling API - ")
+                .contains("(500 Internal Server Error)")
+                .contains("Headers [Content-Type=[application/json]]")
+                .contains("Body: " + SERVER_FAILURE_JSON)
+                .contains(HttpServerErrorException.class.getCanonicalName());
+
+
+        server.verify();
+    }
+
+    private void configureMockRestServiceToFailWithServerError() {
+        server.expect(requestTo("/fail/5xx"))
+                .andRespond(
+                        withServerError()
+                                .body(SERVER_FAILURE_JSON)
+                                .contentType(MediaType.APPLICATION_JSON));
+    }
+}


### PR DESCRIPTION
Split out the RestTemplate generation into a @Bean method with a custom error logger set that logs to body of a 4xx or 5xx response.

There could be some better ways to configure this in Spring, so if there is something obvious let me know in the PR

Added some `@SpringBootTests` to test this functionality.  Note @SpringBootTest is practically starting an embedded instance of the app.  Their may be a narrower test annotation that only sets up the rest repositories in question.  If so please  let me know as well